### PR TITLE
Increase market_domination data

### DIFF
--- a/api/autotrade/routes.py
+++ b/api/autotrade/routes.py
@@ -4,7 +4,10 @@ from sqlmodel import Session
 from database.autotrade_crud import AutotradeCrud
 from tools.enum_definitions import AutotradeSettingsDocument
 from database.utils import get_session
-from autotrade.schemas import AutotradeSettingsResponse, AutotradeSettingsSchema
+from autotrade.schemas import (
+    AutotradeSettingsSchema,
+    TestAutotradeSettingsSchema,
+)
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import ValidationError
 from tools.handle_error import json_response, json_response_error
@@ -50,7 +53,7 @@ def get_settings(session: Session = Depends(get_session)):
 
 @autotrade_settings_blueprint.get(
     "/paper-trading",
-    response_model=AutotradeSettingsResponse,
+    response_model=TestAutotradeSettingsSchema,
     tags=["autotrade settings"],
 )
 def get_test_autotrade_settings(
@@ -73,7 +76,7 @@ def get_test_autotrade_settings(
 
 @autotrade_settings_blueprint.put("/paper-trading", tags=["autotrade settings"])
 def edit_test_autotrade_settings(
-    item: AutotradeSettingsSchema,
+    item: TestAutotradeSettingsSchema,
     session: Session = Depends(get_session),
 ):
     try:

--- a/api/autotrade/schemas.py
+++ b/api/autotrade/schemas.py
@@ -36,7 +36,7 @@ class AutotradeSettingsResponse(StandardResponse):
 
 
 class TestAutotradeSettingsSchema(BaseModel):
-    id: AutotradeSettingsDocument = AutotradeSettingsDocument.settings
+    id: AutotradeSettingsDocument = AutotradeSettingsDocument.test_autotrade_settings
     candlestick_interval: BinanceKlineIntervals = Field(
         default=BinanceKlineIntervals.fifteen_minutes,
     )

--- a/api/charts/routes.py
+++ b/api/charts/routes.py
@@ -101,18 +101,6 @@ def store_market_domination():
         return json_response_error(f"Failed to store market domination data: {error}")
 
 
-@charts_blueprint.get("/md-migration", tags=["charts"])
-def md_migration():
-    try:
-        response = MarketDominationController().mkdm_migration()
-        if response:
-            return json_response_message("Market domination migration completed.")
-    except Exception as error:
-        return json_response_error(
-            f"Failed to migrate market domination data: {error.args[0]}"
-        )
-
-
 @charts_blueprint.get("/top-gainers", tags=["charts"])
 def top_gainers():
     try:

--- a/api/database/api_db.py
+++ b/api/database/api_db.py
@@ -40,7 +40,6 @@ class ApiDb:
         self.init_autotrade_settings()
         self.init_test_autotrade_settings()
         self.create_dummy_bot()
-        self.update_expire_after_seconds("kline", 1728000)
         if os.environ["ENV"] != "ci":
             self.init_symbols()
             # Depends on autotrade settings

--- a/api/database/api_db.py
+++ b/api/database/api_db.py
@@ -40,7 +40,7 @@ class ApiDb:
         self.init_autotrade_settings()
         self.init_test_autotrade_settings()
         self.create_dummy_bot()
-        self.update_expire_after_seconds("market_domination", 1728000)
+        self.update_expire_after_seconds("kline", 1728000)
         if os.environ["ENV"] != "ci":
             self.init_symbols()
             # Depends on autotrade settings
@@ -316,14 +316,14 @@ class ApiDb:
             self.kafka_db.create_collection(
                 collection_name,
                 timeseries={
-                    "timeField": "timestamp",
+                    "timeField": "close_time",
                     "metaField": "symbol",
                     "granularity": "minutes",
                 },
             )
 
             collection.create_index(
-                "timestamp",
+                "close_time",
                 expireAfterSeconds=new_expire_after_seconds,
                 partialFilterExpression={"symbol": {"$exists": True}},
             )

--- a/api/deals/abstractions/spot_deal_abstract.py
+++ b/api/deals/abstractions/spot_deal_abstract.py
@@ -163,6 +163,8 @@ class SpotDealAbstract(DealAbstract):
             )
             # Dispatch real order
             res = self.sell_order(symbol=self.active_bot.pair, qty=qty)
+            if res["status"] != "EXPIRED":
+                res = self.sell_order(symbol=self.active_bot.pair, qty=qty)
 
         price = float(res["price"])
         if price == 0:

--- a/api/paper_trading/routes.py
+++ b/api/paper_trading/routes.py
@@ -44,6 +44,17 @@ def get(
         return BotResponse(message="Failed to find bots!", data=error.json(), error=1)
 
 
+@paper_trading_blueprint.get("/paper-trading/active-pairs", tags=["paper trading"])
+def get_active_pairs(session: Session = Depends(get_session)):
+    try:
+        pairs = PaperTradingTableCrud(session=session).get_active_pairs()
+        return BotResponse(message="Successfully found active pairs!", data=pairs)
+    except BinbotErrors as error:
+        return BotResponse(message=error.message, error=1)
+    except ValueError:
+        return BotResponse(message="No active pairs found!", error=1)
+
+
 @paper_trading_blueprint.get(
     "/paper-trading/{id}", response_model=BotResponse, tags=["paper trading"]
 )
@@ -174,17 +185,6 @@ def deactivate(id: str, session: Session = Depends(get_session)):
         return BotResponse(message=error.message, error=1)
     except ValueError as error:
         return BotResponse(message="Bot not found.", error=1, data=str(error))
-
-
-@paper_trading_blueprint.get("paper-trading/active-pairs", tags=["paper trading"])
-def get_active_pairs(session: Session = Depends(get_session)):
-    try:
-        pairs = PaperTradingTableCrud(session=session).get_active_pairs()
-        return BotResponse(message="Successfully found active pairs!", data=pairs)
-    except BinbotErrors as error:
-        return BotResponse(message=error.message, error=1)
-    except ValueError:
-        return BotResponse(message="No active pairs found!", error=1)
 
 
 @paper_trading_blueprint.post(

--- a/terminal/src/app/components/BarChart.tsx
+++ b/terminal/src/app/components/BarChart.tsx
@@ -1,9 +1,11 @@
+import React from "react";
 import Plot from "react-plotly.js";
 import { listCssColors } from "../../utils/validations";
 import { type FC } from "react";
+import { type GainerLosersData } from "../../features/marketApiSlice";
 
 interface BarChartProps {
-  data: any;
+  data: GainerLosersData;
   width?: string;
   height?: string;
   line1name?: string;
@@ -14,14 +16,43 @@ const BarChart: FC<BarChartProps> = ({
   data,
   width = "100%",
   height = "100%",
-  line1name = "BTC prices",
-  line2name = "USDC balance",
 }) => {
+  // Parse percentages from string values like "33.89%"
+  const gainers_percent = data.gainers.map((v: string) =>
+    typeof v === "string" ? parseFloat(v.replace("%", "")) : v
+  );
+  const losers_percent = data.losers.map((v: string) =>
+    typeof v === "string" ? parseFloat(v.replace("%", "")) : v
+  );
+
+  const reversalIndices: number[] = [];
+  for (let i = 1; i < gainers_percent.length; i++) {
+    const prevDiff = gainers_percent[i - 1] - losers_percent[i - 1];
+    const currDiff = gainers_percent[i] - losers_percent[i];
+    if ((prevDiff <= 0 && currDiff > 0) || (prevDiff >= 0 && currDiff < 0)) {
+      reversalIndices.push(i);
+    }
+  }
+
+  // Prepare vertical line shapes for reversals
+  const reversalShapes = reversalIndices.map((i) => ({
+    type: "line",
+    x0: data.dates[i],
+    x1: data.dates[i],
+    y0: 0,
+    y1: 100,
+    xref: "x",
+    yref: "y",
+    line: {
+      color: "blue",
+      width: 2,
+      dash: "dash",
+    },
+  }));
+
   const layout = {
     dragmode: "zoom",
     autosize: true,
-    line_width: 50,
-    barmode: "stack",
     margin: {
       r: 6,
       t: 35,
@@ -32,16 +63,19 @@ const BarChart: FC<BarChartProps> = ({
     legend: {
       x: 0,
       xanchor: "left",
-      y: 15,
+      y: 1,
     },
     xaxis: {
       autorange: true,
       type: "date",
+      title: { text: "Date", font: { size: 16, family: "Arial" } },
     },
     yaxis: {
       type: "linear",
-      maxPoints: 50,
+      title: { text: "Percent (%)", font: { size: 16, family: "Arial" } },
+      range: [0, 100],
     },
+    shapes: reversalShapes,
   };
 
   return (
@@ -49,20 +83,24 @@ const BarChart: FC<BarChartProps> = ({
       data={[
         {
           x: data.dates,
-          y: data.gainers_percent,
-          type: "bar",
-          marker: { color: listCssColors[8] },
-          name: line1name,
-          text: data.gainers,
-        },
+          y: gainers_percent,
+          type: "scatter",
+          mode: "lines",
+          fill: "tozeroy",
+          fillcolor: listCssColors[8],
+          line: { color: listCssColors[8] },
+          name: "gainers_percent",
+        } as any,
         {
           x: data.dates,
-          y: data.losers_percent,
-          type: "bar",
-          marker: { color: listCssColors[2] },
-          name: line2name,
-          text: data.losers,
-        },
+          y: losers_percent,
+          type: "scatter",
+          mode: "lines",
+          fill: "tonexty",
+          fillcolor: listCssColors[2],
+          line: { color: listCssColors[2] },
+          name: "losers_percent",
+        } as any,
       ]}
       layout={layout}
       useResizeHandler={true}

--- a/terminal/src/app/components/GainersLosers.tsx
+++ b/terminal/src/app/components/GainersLosers.tsx
@@ -1,11 +1,17 @@
+import React from "react";
 import Card from "react-bootstrap/Card";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import { computeWinnerLoserProportions } from "../../utils/dashboard-computations";
 import { roundDecimals } from "../../utils/math";
 import GainersLosersCard from "./GainersLosersCard";
+import { type BinanceTicker24 } from "../../features/binanceApiSlice";
 
-export default function GainersLosers({ data }) {
+export interface GainersLosersProps {
+  data: BinanceTicker24[];
+};
+
+export default function GainersLosers({ data }: GainersLosersProps) {
   const { gainerCount, gainerAccumulator, loserAccumulator, loserCount } =
     computeWinnerLoserProportions(data);
   // Top 10

--- a/terminal/src/app/components/GainersLosersCard.tsx
+++ b/terminal/src/app/components/GainersLosersCard.tsx
@@ -1,6 +1,12 @@
+import React from "react";
 import { Badge, Card, ListGroup } from "react-bootstrap";
+import { type GainersLosersProps } from "./GainersLosers";
 
-const GainersLosersCard = ({ data, title }) => {
+interface GainersLosersCardProps extends GainersLosersProps {
+  title: string;
+}
+
+const GainersLosersCard = ({ data, title }: GainersLosersCardProps) => {
   return (
     <Card.Body>
       <Card.Title>{title}</Card.Title>
@@ -19,7 +25,7 @@ const GainersLosersCard = ({ data, title }) => {
                   {x.priceChangePercent + "%"}
                 </Badge>
               </ListGroup.Item>
-            ),
+            )
         )}
       </ListGroup>
     </Card.Body>

--- a/terminal/src/app/components/ReversalBarChart.tsx
+++ b/terminal/src/app/components/ReversalBarChart.tsx
@@ -3,6 +3,7 @@ import { Card, Col, Row } from "react-bootstrap";
 import { type GainerLosersData } from "../../features/marketApiSlice";
 import { useBreakpoint } from "../hooks";
 import BarChart from "./BarChart";
+import moment from "moment";
 
 type ReversalBarChartProps = {
   chartData: GainerLosersData;
@@ -27,6 +28,7 @@ const ReversalBarChart: FC<ReversalBarChartProps> = ({ chartData, legend }) => {
 
   const gainers = data.gainers_count;
   const losers = data.losers_count;
+
   return (
     <Card className="card-chart">
       <Card.Header>
@@ -74,7 +76,7 @@ const ReversalBarChart: FC<ReversalBarChartProps> = ({ chartData, legend }) => {
         {data.dates && (
           <div className="card-stats">
             <i className="fa fa-check" /> Last updated{" "}
-            {data.dates[data.dates.length - 1]}
+            {moment(data.dates[0]).format("DD/MM/YYYY HH:mm")}
           </div>
         )}
       </Card.Footer>

--- a/terminal/src/app/pages/Autotrade.tsx
+++ b/terminal/src/app/pages/Autotrade.tsx
@@ -8,9 +8,7 @@ import {
   Row,
   ToggleButton,
   ButtonGroup,
-  InputGroup,
 } from "react-bootstrap";
-import { InputTooltip } from "../components/InputTooltip";
 import { useForm, type FieldValues } from "react-hook-form";
 import {
   useEditSettingsMutation,

--- a/terminal/src/app/pages/TestAutotrade.tsx
+++ b/terminal/src/app/pages/TestAutotrade.tsx
@@ -7,7 +7,7 @@ import { useAppDispatch, useAppSelector } from "../hooks";
 import { type AppDispatch } from "../store";
 import { BinanceKlineintervals } from "../../utils/enums";
 import { useEditTestSettingsMutation, useGetTestSettingsQuery } from "../../features/testAutotradeApiSlice";
-import { selectTestSettings, setTestSettingsField, setTestSettingsToggle } from "../../features/testAutotradeSlice";
+import { selectTestSettings, setTestSettings, setTestSettingsField, setTestSettingsToggle } from "../../features/testAutotradeSlice";
 
 export const TestAutotradePage: FC<{}> = () => {
   const { data } = useGetTestSettingsQuery();
@@ -20,12 +20,22 @@ export const TestAutotradePage: FC<{}> = () => {
     setValue,
     reset,
     handleSubmit,
+    watch,
     formState: { errors },
   } = useForm<FieldValues>({
     mode: "onTouched",
     reValidateMode: "onBlur",
     defaultValues: {
       candlestick_interval: settings.candlestick_interval,
+      autotrade: settings.autotrade,
+      max_active_autotrade_bots: settings.max_active_autotrade_bots,
+      base_order_size: settings.base_order_size,
+      fiat: settings.fiat,
+      stop_loss: settings.stop_loss,
+      take_profit: settings.take_profit,
+      trailling: settings.trailling,
+      trailling_deviation: settings.trailling_deviation,
+      trailling_profit: settings.trailling_profit,
     },
   });
 
@@ -46,10 +56,42 @@ export const TestAutotradePage: FC<{}> = () => {
   };
 
   useEffect(() => {
+
     if (data) {
-      reset(data);
+      dispatch(setTestSettings(data));
     }
-  }, [data, dispatch, reset, setValue]);
+  }, [data]);
+
+useEffect(() => {
+    const { unsubscribe } = watch((v, { name, type }) => {
+      if (v && v?.[name]) {
+        if (typeof v[name] === "boolean") {
+          dispatch(setTestSettingsToggle({ name, value: v[name] }));
+        } else {
+          dispatch(
+            setTestSettingsField({ name, value: v[name] as number | string })
+          );
+        }
+      }
+    });
+
+    if (settings) {
+      reset({
+        candlestick_interval: settings.candlestick_interval,
+        autotrade: settings.autotrade,
+        max_active_autotrade_bots: settings.max_active_autotrade_bots,
+        base_order_size: settings.base_order_size,
+        fiat: settings.fiat,
+        stop_loss: settings.stop_loss,
+        take_profit: settings.take_profit,
+        trailling: settings.trailling,
+        trailling_deviation: settings.trailling_deviation,
+        trailling_profit: settings.trailling_profit,
+      });
+    }
+
+    return () => unsubscribe();
+  }, [dispatch, settings]);
 
   return (
     <Container>

--- a/terminal/src/features/binanceApiSlice.tsx
+++ b/terminal/src/features/binanceApiSlice.tsx
@@ -39,7 +39,7 @@ export const binanceApiSlice = createApi({
         url: `${import.meta.env.VITE_TICKER_24}` || "/gainers-losers",
         providesTags: ["binance"],
       }),
-      transformResponse: (data, meta, arg) => {
+      transformResponse: (data: BinanceTicker24[], meta) => {
         if (!meta.response.ok) {
           notifification("error", meta.response.statusText);
         }

--- a/terminal/src/features/testAutotradeSlice.tsx
+++ b/terminal/src/features/testAutotradeSlice.tsx
@@ -1,7 +1,7 @@
 import { BinanceKlineintervals, CloseConditions } from "../utils/enums";
 import { createAppSlice } from "../app/createAppSlice";
 import { type PayloadAction } from "@reduxjs/toolkit";
-import type { AutotradeSettingsFormBoolean, AutotradeSettingsFormField, AutotradeSettingsObject } from "./autotradeSlice";
+import type { AutotradeSettingsFormBoolean, AutotradeSettingsFormField } from "./autotradeSlice";
 import { type AutotradeSettings } from "./autotradeApiSlice";
 
 export const initialAutotradeSettings: AutotradeSettings = {
@@ -44,8 +44,8 @@ export const testAutotradeSettingsSlice = createAppSlice({
       },
     ),
     setTestSettings: create.reducer(
-      (state, { payload }: PayloadAction<AutotradeSettingsObject>) => {
-        state.settings = payload.settings;
+      (state, { payload }: PayloadAction<AutotradeSettings>) => {
+        state.settings = payload;
       },
     ),
   }),


### PR DESCRIPTION
It's not possible to integrate market_domination data with candlesticks, so increase market_domination data by increasing the expire after seconds, this will allow data to stay in the DB longer for AI minimum requirements.

Market domination's main data component is the 24-hour ticker. This ticker apparently uses book order data to build up from. Since we don't store such low level data (it'd be a huge database consuming a lot of space), we can't merge with candlesticks.

Candlesticks are an approximation of the aggregated book orders, they are not exactly the same. That's why even on Binance's data, candlesticks and 24-hour tickers never match.