### PR TITLE
Replace bitnami Kafka image with soldevelo/kafka

### DIFF
--- a/compose-development.yml
+++ b/compose-development.yml
@@ -53,7 +53,7 @@ services:
       start_period: 40s
 
   kafka:
-    image: bitnami/kafka:3.9
+    image: soldevelo/kafka:3.9
     container_name: binquant_kafka
     networks:
       - kafka_network


### PR DESCRIPTION
I suggest this change because the Bitnami Kafka image is now behind a paywall and no longer publicly available, which prevents CI/CD and local environments from functioning properly.

Soldevelo image is a drop-in replacement that remains fully compatible with Bitnami’s configuration and environment variables.

Link: https://hub.docker.com/u/soldevelo
