### PR TITLE
Cancel stop orders before placing a new one

### DIFF
--- a/api/deals/gateway.py
+++ b/api/deals/gateway.py
@@ -7,7 +7,7 @@ from exchange_apis.kucoin.deals.short_deal import KucoinShortDeal
 from databases.crud.autotrade_crud import AutotradeCrud
 from exchange_apis.binance.deals.short import BinanceShortDeal
 from exchange_apis.binance.deals.long import BinanceLongDeal
-from exchange_apis.kucoin.futures.long_deal import FuturesLongDeal
+from exchange_apis.kucoin.futures.position_deal import PositionDeal
 
 
 class DealGateway:
@@ -29,18 +29,21 @@ class DealGateway:
             BinanceShortDeal,
             KucoinLongDeal,
             KucoinShortDeal,
-            FuturesLongDeal,
+            PositionDeal,
         ]
         if self.autotrade_settings.exchange_id == ExchangeId.KUCOIN:
-            if bot.strategy == Strategy.margin_short:
-                self.deal = KucoinShortDeal(bot, db_table=db_table)
+            if bot.market_type == MarketType.FUTURES:
+                self.deal = PositionDeal(bot, db_table=db_table)
             else:
-                if bot.market_type == MarketType.FUTURES:
-                    self.deal = FuturesLongDeal(bot, db_table=db_table)
+                if bot.strategy == Strategy.margin_short:
+                    self.deal = KucoinShortDeal(bot, db_table=db_table)
                 else:
-                    raise NotImplementedError(
-                        "Spot trading is not supported for Kucoin exchange"
-                    )
+                    if bot.market_type == MarketType.FUTURES:
+                        self.deal = PositionDeal(bot, db_table=db_table)
+                    else:
+                        raise NotImplementedError(
+                            "Spot trading is not supported for Kucoin exchange"
+                        )
         else:
             if bot.strategy == Strategy.margin_short:
                 self.deal = BinanceShortDeal(bot, db_table=db_table)

--- a/api/exchange_apis/kucoin/futures/api.py
+++ b/api/exchange_apis/kucoin/futures/api.py
@@ -71,10 +71,8 @@ class KucoinFutures(KucoinRest):
 
     def __init__(self):
         self.config = Config()
-        self.DEFAULT_LEVERAGE = (
-            1.5  # assuming stop loss 3% by default, conservative risk
-        )
-        self.DEFAULT_MULTIPLIER = 1  # for USDT-M futures
+        self.DEFAULT_LEVERAGE = 3
+        self.DEFAULT_MULTIPLIER = 1
         super().__init__(
             key=self.config.kucoin_key,
             secret=self.config.kucoin_secret,

--- a/api/exchange_apis/kucoin/futures/futures_deal.py
+++ b/api/exchange_apis/kucoin/futures/futures_deal.py
@@ -22,7 +22,7 @@ from exchange_apis.kucoin.futures.balance import KucoinFuturesBalance
 from bots.models import OrderModel
 
 
-class KucoinFuturesDeal(KucoinBaseBalance):
+class KucoinPositionDeal(KucoinBaseBalance):
     """
     Futures-only deal entry implementation (USDT-M).
 

--- a/api/exchange_apis/kucoin/futures/position_deal.py
+++ b/api/exchange_apis/kucoin/futures/position_deal.py
@@ -15,16 +15,19 @@ from pybinbot import (
 from databases.tables.bot_table import BotTable, PaperTradingTable
 from databases.crud.paper_trading_crud import PaperTradingTableCrud
 from bots.models import BotModel, OrderModel
-from exchange_apis.kucoin.futures.futures_deal import KucoinFuturesDeal
+from exchange_apis.kucoin.futures.futures_deal import KucoinPositionDeal
 from kucoin_universal_sdk.generate.futures.order.model_add_order_req import (
     AddOrderReq,
 )
 from kucoin_universal_sdk.model.common import RestError
 
 
-class FuturesLongDeal(KucoinFuturesDeal):
+class PositionDeal(KucoinPositionDeal):
     """
-    Long deal implementation for Kucoin futures trading.
+    Position-based implementation for Kucoin futures trading.
+
+    Previously called FuturesLongDeal, but long or short position logic is all handled within this class
+    since Kucoin Futures logic allows easy isolated margin and switching positions.
 
     Happens after open_deal is executed
     formerly known as streaming updates


### PR DESCRIPTION
This is necessary especially when deal is updated from Terminal dashboard and reactivation