### PR TITLE
Migrate advancers-decliners to market_breadth

### DIFF
--- a/api/charts/controllers.py
+++ b/api/charts/controllers.py
@@ -5,6 +5,7 @@ from databases.crud.autotrade_crud import AutotradeCrud
 from charts.models import AdrSeriesDb
 from databases.db import Database
 from databases.crud.symbols_crud import SymbolsCrud
+from pymongo.errors import BulkWriteError
 from pybinbot import ExchangeId, KucoinApi, BinanceApi
 from tools.config import Config
 from kucoin_universal_sdk.generate.spot.market.model_get_symbol_resp import (
@@ -53,15 +54,36 @@ class MarketDominationController(Database):
         legacy_collection = self.kafka_db.advancers_decliners
         target_collection = self.kafka_db.market_breadth
 
-        migrated_count = 0
+        documents_to_insert = []
         for document in legacy_collection.find({}):
             document["source"] = document.get("source") or ExchangeId.BINANCE.value
+            documents_to_insert.append(document)
 
-            if target_collection.count_documents({"_id": document["_id"]}, limit=1):
-                continue
+        if not documents_to_insert:
+            logging.info("No ADR documents needed migration into market_breadth")
+            return 0
 
-            target_collection.insert_one(document)
-            migrated_count += 1
+        try:
+            result = target_collection.insert_many(documents_to_insert, ordered=False)
+            migrated_count = len(result.inserted_ids)
+        except BulkWriteError as exc:
+            write_errors = exc.details.get("writeErrors", [])
+            duplicate_errors = [
+                error for error in write_errors if error.get("code") == 11000
+            ]
+            non_duplicate_errors = [
+                error for error in write_errors if error.get("code") != 11000
+            ]
+
+            if non_duplicate_errors:
+                raise
+
+            migrated_count = len(
+                exc.details.get("writeResult", {}).get("insertedIds", [])
+            )
+            if not migrated_count:
+                attempted = len(documents_to_insert)
+                migrated_count = max(attempted - len(duplicate_errors), 0)
 
         if migrated_count:
             logging.info(

--- a/api/charts/controllers.py
+++ b/api/charts/controllers.py
@@ -1,13 +1,11 @@
-import re
+import logging
 from datetime import datetime, timezone
 from typing import Any, Iterable
 from databases.crud.autotrade_crud import AutotradeCrud
 from charts.models import AdrSeriesDb
 from databases.db import Database
 from databases.crud.symbols_crud import SymbolsCrud
-from pybinbot import ExchangeId, KucoinApi, round_numbers, BinanceApi
-from databases.crud.paper_trading_crud import PaperTradingTableCrud
-from databases.crud.bot_crud import BotTableCrud
+from pybinbot import ExchangeId, KucoinApi, BinanceApi
 from tools.config import Config
 from kucoin_universal_sdk.generate.spot.market.model_get_symbol_resp import (
     GetSymbolResp,
@@ -34,6 +32,45 @@ class MarketDominationController(Database):
             secret=self.config.kucoin_secret,
             passphrase=self.config.kucoin_passphrase,
         )
+
+    def _ensure_market_breadth_collection(self) -> None:
+        if "market_breadth" in self.kafka_db.list_collection_names():
+            return
+
+        self.kafka_db.create_collection(
+            "market_breadth",
+            timeseries={
+                "timeField": "timestamp",
+                "metaField": "source",
+                "granularity": "hours",
+            },
+        )
+        logging.info("Created time-series collection market_breadth")
+
+    def migrate_adrs(self) -> int:
+        self._ensure_market_breadth_collection()
+
+        legacy_collection = self.kafka_db.advancers_decliners
+        target_collection = self.kafka_db.market_breadth
+
+        migrated_count = 0
+        for document in legacy_collection.find({}):
+            document["source"] = document.get("source") or ExchangeId.BINANCE.value
+
+            if target_collection.count_documents({"_id": document["_id"]}, limit=1):
+                continue
+
+            target_collection.insert_one(document)
+            migrated_count += 1
+
+        if migrated_count:
+            logging.info(
+                "Migrated %s ADR documents into market_breadth", migrated_count
+            )
+        else:
+            logging.info("No ADR documents needed migration into market_breadth")
+
+        return migrated_count
 
     def _get_market_breadth_tickers(self) -> tuple[Iterable[Any], datetime | None]:
         if self.exchange == ExchangeId.KUCOIN:
@@ -130,21 +167,26 @@ class MarketDominationController(Database):
         Store ticker 24 data every 30 min
         and calculate ADR + Strength Index
         """
+        self._ensure_market_breadth_collection()
         market_tickers, fallback_timestamp = self._get_market_breadth_tickers()
         adr_data = self._calculate_adr_series_data(market_tickers, fallback_timestamp)
-        response = self.kafka_db.advancers_decliners.insert_one(adr_data.model_dump())
+        response = self.kafka_db.market_breadth.insert_one(adr_data.model_dump())
         return response
 
-    def get_adrs(self, size=7, window=3) -> dict | None:
+    def get_adrs(
+        self, size: int = 7, window: int = 3, exchange: ExchangeId | None = None
+    ) -> dict | None:
         """
         Get ADRs historical data with moving average of 'adr', using ObjectId _id for date.
 
         Args:
             size (int, optional): Number of data points to retrieve. Defaults to 7 (1 week).
             window (int, optional): Window size for moving average. Defaults to 3.
+            exchange (ExchangeId, optional): Exchange ID to filter data. Defaults to None.
         Returns:
             list: A list of ADR data points with moving average.
         """
+        self._ensure_market_breadth_collection()
         fetch_size = size + window - 1
         pipeline = [
             {"$addFields": {"timestamp_dt": "$timestamp"}},
@@ -214,13 +256,15 @@ class MarketDominationController(Database):
             },
             {"$project": {"_id": 0}},
         ]
-        results = self.kafka_db.advancers_decliners.aggregate(pipeline)
+        if exchange:
+            pipeline.insert(0, {"$match": {"source": exchange.value}})
+        results = self.kafka_db.market_breadth.aggregate(pipeline)
         data = list(results)
         if len(data) > 0:
             return data[0]
         return None
 
-    def gainers_losers(self):
+    def gainers_losers(self) -> tuple[Iterable[Any], Iterable[Any]]:
         """
         Get market top gainers of the day
 
@@ -252,43 +296,3 @@ class MarketDominationController(Database):
         )
 
         return gainers[:10], losers[:10]
-
-    def algo_performance(self, paper_trading: bool = False) -> dict:
-        """
-        Get algorithm performance data
-        from bots in the last month
-
-        1. Get bots
-        2. Parse names
-        3. Do an aggregation of all profits and return net profit
-        """
-        algo_performance: dict = {}
-
-        if paper_trading:
-            bots_crud: PaperTradingTableCrud | BotTableCrud = PaperTradingTableCrud()
-
-        else:
-            bots_crud = BotTableCrud()
-
-        bots = bots_crud.get()
-        if not bots:
-            return algo_performance
-        else:
-            for bot in bots:
-                match_name = re.match(
-                    r"^(.*?)(?=_[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2})", bot.name
-                )
-                if match_name:
-                    key = match_name.group(1).lower()
-                    if key not in algo_performance:
-                        algo_performance[key] = {"net_profit": 0.0, "bots_count": 0}
-
-                    if bot.deal.closing_price > 0:
-                        algo_performance[key]["net_profit"] += round_numbers(
-                            (bot.deal.closing_price - bot.deal.opening_price)
-                            / bot.deal.closing_price
-                        )
-
-                    algo_performance[key]["bots_count"] += 1
-
-        return algo_performance

--- a/api/charts/controllers.py
+++ b/api/charts/controllers.py
@@ -54,6 +54,12 @@ class MarketDominationController(Database):
         legacy_collection = self.kafka_db.advancers_decliners
         target_collection = self.kafka_db.market_breadth
 
+        if target_collection.estimated_document_count() > 0:
+            logging.info(
+                "Skipping ADR migration because market_breadth already contains data"
+            )
+            return 0
+
         documents_to_insert = []
         for document in legacy_collection.find({}):
             document["source"] = document.get("source") or ExchangeId.BINANCE.value

--- a/api/charts/routes.py
+++ b/api/charts/routes.py
@@ -76,23 +76,3 @@ def get_adr_series(size: int = 14, session: Session = Depends(get_session)):
 
     except Exception as error:
         return json_response_error(f"Failed to retrieve ADR series data: {error}")
-
-
-@charts_blueprint.get(
-    "/algorithm-performance",
-    tags=["charts"],
-    summary="Get algorithm profit and loss",
-    response_model=AdrSeriesResponse,
-)
-def algorithm_performance():
-    algorithm_performance_data = MarketDominationController().algo_performance()
-    if algorithm_performance_data:
-        return json_response(
-            {
-                "data": algorithm_performance_data,
-                "message": "Successfully retrieved algorithm performance data.",
-                "error": 0,
-            }
-        )
-    else:
-        raise HTTPException(404, detail="No algorithm performance data found")

--- a/api/databases/api_db.py
+++ b/api/databases/api_db.py
@@ -1,4 +1,5 @@
 import logging
+from charts.controllers import MarketDominationController
 from databases.tables.inquiry_table import InquiryTable
 from databases.symbols_etl import SymbolDataEtl
 from databases.tables.autotrade_table import AutotradeTable, TestAutotradeTable
@@ -49,8 +50,14 @@ class ApiDb:
         # Depends on autotrade settings
         self.init_balances()
         self.init_inquiries()
+        self.init_market_breadth()
 
         logging.info("Finishing db operations")
+
+    def init_market_breadth(self):
+        controller = MarketDominationController()
+        controller.migrate_adrs()
+        logging.debug("Finished initializing market breadth data")
 
     def run_migrations(self):
         """
@@ -241,8 +248,7 @@ class ApiDb:
                 role=role,
                 full_name="Admin",
             )
-            if user_data:
-                self.session.add(user_data)
+            self.session.add(user_data)
 
         service_username = self.config.service_user
         service_email = self.config.service_email
@@ -263,8 +269,6 @@ class ApiDb:
             self.session.add(service_user_data)
 
         self.session.commit()
-        self.session.refresh(user_data)
-        self.session.refresh(service_user_data)
         return
 
     def create_dummy_bot(self):

--- a/api/databases/api_db.py
+++ b/api/databases/api_db.py
@@ -57,7 +57,6 @@ class ApiDb:
     def init_market_breadth(self):
         controller = MarketDominationController()
         controller.migrate_adrs()
-        logging.debug("Finished initializing market breadth data")
 
     def run_migrations(self):
         """

--- a/api/tests/test_market_domination_controller.py
+++ b/api/tests/test_market_domination_controller.py
@@ -6,14 +6,70 @@ from databases.tables.autotrade_table import AutotradeTable
 from pybinbot import ExchangeId
 
 
+class CollectionStub:
+    def __init__(self):
+        self.inserted_docs = []
+
+    def insert_one(self, doc):
+        self.inserted_docs.append(doc)
+        return doc
+
+
 def _make_controller(exchange_id: ExchangeId, fiat: str = "USDC"):
     controller = MarketDominationController.__new__(MarketDominationController)
     controller.exchange = exchange_id
     controller.autotrade_settings = AutotradeTable(fiat=fiat, exchange_id=exchange_id)
     controller.kafka_db = SimpleNamespace(
-        advancers_decliners=SimpleNamespace(insert_one=lambda doc: doc)
+        list_collection_names=lambda: ["market_breadth"],
+        market_breadth=CollectionStub(),
     )
     return controller
+
+
+def test_migrate_adrs_copies_legacy_documents_to_market_breadth():
+    legacy_docs = [
+        {
+            "_id": "legacy-binance",
+            "timestamp": datetime(2025, 9, 14, 0, 5, 13),
+            "advancers": 187,
+            "decliners": 57,
+            "total_volume": 6912803774816.687,
+            "strength_index": 0.5924651628279104,
+        },
+        {
+            "_id": "legacy-kucoin",
+            "timestamp": datetime(2026, 4, 11, 5, 27, 0),
+            "advancers": 443,
+            "decliners": 445,
+            "total_volume": 82548895987280.3,
+            "strength_index": 0.20350799552462534,
+            "source": ExchangeId.KUCOIN.value,
+        },
+    ]
+
+    inserted_docs: list[dict] = []
+
+    class MarketBreadthStub(CollectionStub):
+        def count_documents(self, query, limit=0):
+            return int(any(doc["_id"] == query["_id"] for doc in inserted_docs))
+
+        def insert_one(self, doc):
+            inserted_docs.append(doc)
+            return doc
+
+    controller = _make_controller(ExchangeId.BINANCE)
+    controller.kafka_db = SimpleNamespace(
+        list_collection_names=lambda: [],
+        create_collection=lambda *args, **kwargs: None,
+        advancers_decliners=SimpleNamespace(find=lambda query=None: legacy_docs),
+        market_breadth=MarketBreadthStub(),
+    )
+
+    migrated_count = controller.migrate_adrs()
+
+    assert migrated_count == 2
+    assert inserted_docs[0]["source"] == ExchangeId.BINANCE.value
+    assert inserted_docs[1]["source"] == ExchangeId.KUCOIN.value
 
 
 def test_ingest_adp_data_uses_binance_ticker_payload():
@@ -46,6 +102,7 @@ def test_ingest_adp_data_uses_binance_ticker_payload():
 
     inserted = controller.ingest_adp_data()
 
+    assert controller.kafka_db.market_breadth.inserted_docs[0] == inserted
     assert inserted["advancers"] == 1
     assert inserted["decliners"] == 1
     assert inserted["total_volume"] == 7.0
@@ -90,6 +147,7 @@ def test_ingest_adp_data_uses_kucoin_all_tickers_payload():
 
     inserted = controller.ingest_adp_data()
 
+    assert controller.kafka_db.market_breadth.inserted_docs[0] == inserted
     assert inserted["advancers"] == 1
     assert inserted["decliners"] == 1
     assert inserted["total_volume"] == 700.0

--- a/api/tests/test_market_domination_controller.py
+++ b/api/tests/test_market_domination_controller.py
@@ -9,10 +9,21 @@ from pybinbot import ExchangeId
 class CollectionStub:
     def __init__(self):
         self.inserted_docs = []
+        self.aggregate_pipeline = None
 
     def insert_one(self, doc):
         self.inserted_docs.append(doc)
         return doc
+
+    def insert_many(self, docs, ordered=False):
+        self.inserted_docs.extend(docs)
+        return SimpleNamespace(
+            inserted_ids=[doc["_id"] for doc in docs if "_id" in doc]
+        )
+
+    def aggregate(self, pipeline):
+        self.aggregate_pipeline = pipeline
+        return []
 
 
 def _make_controller(exchange_id: ExchangeId, fiat: str = "USDC"):
@@ -50,12 +61,9 @@ def test_migrate_adrs_copies_legacy_documents_to_market_breadth():
     inserted_docs: list[dict] = []
 
     class MarketBreadthStub(CollectionStub):
-        def count_documents(self, query, limit=0):
-            return int(any(doc["_id"] == query["_id"] for doc in inserted_docs))
-
-        def insert_one(self, doc):
-            inserted_docs.append(doc)
-            return doc
+        def insert_many(self, docs, ordered=False):
+            inserted_docs.extend(docs)
+            return SimpleNamespace(inserted_ids=[doc["_id"] for doc in docs])
 
     controller = _make_controller(ExchangeId.BINANCE)
     controller.kafka_db = SimpleNamespace(
@@ -70,6 +78,16 @@ def test_migrate_adrs_copies_legacy_documents_to_market_breadth():
     assert migrated_count == 2
     assert inserted_docs[0]["source"] == ExchangeId.BINANCE.value
     assert inserted_docs[1]["source"] == ExchangeId.KUCOIN.value
+
+
+def test_get_adrs_filters_by_exchange_when_exchange_arg_is_set():
+    controller = _make_controller(ExchangeId.BINANCE)
+
+    controller.get_adrs(exchange=ExchangeId.KUCOIN)
+
+    assert controller.kafka_db.market_breadth.aggregate_pipeline[0] == {
+        "$match": {"source": ExchangeId.KUCOIN.value}
+    }
 
 
 def test_ingest_adp_data_uses_binance_ticker_payload():

--- a/api/tests/test_market_domination_controller.py
+++ b/api/tests/test_market_domination_controller.py
@@ -25,6 +25,9 @@ class CollectionStub:
         self.aggregate_pipeline = pipeline
         return []
 
+    def estimated_document_count(self):
+        return len(self.inserted_docs)
+
 
 def _make_controller(exchange_id: ExchangeId, fiat: str = "USDC"):
     controller = MarketDominationController.__new__(MarketDominationController)
@@ -78,6 +81,20 @@ def test_migrate_adrs_copies_legacy_documents_to_market_breadth():
     assert migrated_count == 2
     assert inserted_docs[0]["source"] == ExchangeId.BINANCE.value
     assert inserted_docs[1]["source"] == ExchangeId.KUCOIN.value
+
+
+def test_migrate_adrs_skips_when_market_breadth_already_has_data():
+    controller = _make_controller(ExchangeId.BINANCE)
+    controller.kafka_db.market_breadth.inserted_docs.append({"_id": "existing"})
+    controller.kafka_db.advancers_decliners = SimpleNamespace(
+        find=lambda query=None: (_ for _ in ()).throw(
+            AssertionError("legacy collection should not be read")
+        )
+    )
+
+    migrated_count = controller.migrate_adrs()
+
+    assert migrated_count == 0
 
 
 def test_get_adrs_filters_by_exchange_when_exchange_arg_is_set():


### PR DESCRIPTION
Initial reason to migrate was to add the `source` field, but because this is a time series data, we can't just backfill. But we need to update the collection to a better name anyway - market_breadth. This should be a more descriptive and consistent name for the whole stack (binbot, binquant, terminal)