### PR TITLE
Deduct KuCoin futures deposits from portfolio totals and expose `total_deposit`

### DIFF
--- a/api/account/controller.py
+++ b/api/account/controller.py
@@ -1,7 +1,7 @@
 from account.schemas import BalanceSchema, KucoinBalance
 from databases.crud.balances_crud import BalancesCrud
 from exchange_apis.binance.assets import Assets
-from pybinbot import ExchangeId, round_numbers, KucoinApi, KucoinFutures
+from pybinbot import ExchangeId, round_numbers, KucoinApi, KucoinFutures, BinbotErrors
 from databases.utils import get_session
 from sqlmodel import Session
 from exchange_apis.kucoin.deals.base import KucoinBaseBalance
@@ -32,6 +32,47 @@ class ConsolidatedAccounts:
         self.autotrade_settings = self.binance_assets.autotrade_settings
         self.balances_crud = BalancesCrud(session=self.session)
         self.fiat = self.autotrade_settings.fiat
+
+    @staticmethod
+    def _deposit_amount(entry) -> float:
+        if isinstance(entry, dict):
+            amount = entry.get("amount") or entry.get("size") or 0
+        else:
+            amount = getattr(entry, "amount", None)
+            if amount is None:
+                amount = getattr(entry, "size", 0)
+
+        try:
+            return float(amount)
+        except (TypeError, ValueError):
+            return 0.0
+
+    def get_total_deposit(self) -> float:
+        if self.autotrade_settings.exchange_id != ExchangeId.KUCOIN:
+            return 0.0
+
+        try:
+            deposits = self.kucoin_futures_api.get_deposit_history()
+        except BinbotErrors:
+            return 0.0
+
+        if not deposits:
+            return 0.0
+
+        if isinstance(deposits, dict):
+            candidates = (
+                deposits.get("items")
+                or deposits.get("data")
+                or deposits.get("deposits")
+                or []
+            )
+        else:
+            candidates = deposits
+
+        if isinstance(candidates, dict):
+            candidates = candidates.get("items") or []
+
+        return sum(self._deposit_amount(deposit) for deposit in candidates)
 
     def get_balance(self) -> BalanceSchema:
         """
@@ -94,15 +135,19 @@ class ConsolidatedAccounts:
         result.estimated_total_fiat = estimated_total_fiat
         result.fiat_available = fiat_available
         result.fiat_currency = self.autotrade_settings.fiat
+        result.total_deposit = self.get_total_deposit()
 
         return result
 
     def store_balance(self):
         if self.autotrade_settings.exchange_id == ExchangeId.KUCOIN:
             kucoin_balances = self.get_balance()
+            net_estimated_total_fiat = (
+                kucoin_balances.estimated_total_fiat - kucoin_balances.total_deposit
+            )
             response = self.balances_crud.create_balance_series(
                 kucoin_balances.balances,
-                round_numbers(kucoin_balances.estimated_total_fiat, 4),
+                round_numbers(net_estimated_total_fiat, 4),
                 exchange_id=ExchangeId.KUCOIN,
             )
             return response

--- a/api/account/controller.py
+++ b/api/account/controller.py
@@ -49,7 +49,9 @@ class ConsolidatedAccounts:
 
     def get_total_deposit(self) -> float:
         if self.autotrade_settings.exchange_id != ExchangeId.KUCOIN:
-            return 0.0
+            raise NotImplementedError(
+                "Total deposit aggregation is only implemented for KuCoin."
+            )
 
         try:
             deposits = self.kucoin_futures_api.get_deposit_history()
@@ -135,7 +137,10 @@ class ConsolidatedAccounts:
         result.estimated_total_fiat = estimated_total_fiat
         result.fiat_available = fiat_available
         result.fiat_currency = self.autotrade_settings.fiat
-        result.total_deposit = self.get_total_deposit()
+        if self.autotrade_settings.exchange_id == ExchangeId.KUCOIN:
+            result.total_deposit = self.get_total_deposit()
+        else:
+            result.total_deposit = 0.0
 
         return result
 

--- a/api/account/schemas.py
+++ b/api/account/schemas.py
@@ -39,6 +39,10 @@ class BalanceSchema(BaseBalance):
     balances: Dict[str, float] = Field(
         default={}, description="Dictionary of asset balances 'BTC': 0.5, 'ETH': 0.01"
     )
+    total_deposit: float = Field(
+        default=0,
+        description="Aggregated total deposits from KuCoin Futures deposit history",
+    )
 
 
 class KucoinBalanceResponse(StandardResponse):

--- a/terminal/src/app/pages/Dashboard.tsx
+++ b/terminal/src/app/pages/Dashboard.tsx
@@ -37,7 +37,10 @@ const usePortfolioPnlDetails = (
   const benchmarkSeries =
     benchmark?.benchmarkData?.fiat ?? benchmark?.benchmarkData?.fiat;
   const previousPortfolioValue = benchmarkSeries?.[benchmarkSeries.length - 1];
-  const latestPortfolioValue = accountData?.estimated_total_fiat;
+  const latestPortfolioValue =
+    accountData?.estimated_total_fiat !== undefined
+      ? accountData.estimated_total_fiat - (accountData?.total_deposit ?? 0)
+      : undefined;
   const portfolioPnlValue =
     latestPortfolioValue !== undefined && previousPortfolioValue !== undefined
       ? latestPortfolioValue - previousPortfolioValue
@@ -94,6 +97,8 @@ export const DashboardPage: FC<{}> = () => {
   const { portfolioPnlValue, portfolioPnlPercentage, portfolioPnlClass } =
     usePortfolioPnlDetails(benchmark, accountData);
   const portfolioSharpe = benchmark?.portfolioStats?.sharpe;
+  const netTotalBalance =
+    (accountData?.estimated_total_fiat ?? 0) - (accountData?.total_deposit ?? 0);
   const btcSharpe = benchmark?.portfolioStats?.btc_sharpe;
   const topAlgoCounts = new Set(
     algoRanking
@@ -161,7 +166,7 @@ export const DashboardPage: FC<{}> = () => {
                       Total Balance
                     </p>
                     <Card.Title as="h3" className="fs-4 text-end text-info">
-                      {roundDecimals(accountData?.estimated_total_fiat, 2)}{" "}
+                      {roundDecimals(netTotalBalance, 2)}{" "}
                       {accountData.fiat_currency}
                     </Card.Title>
                   </Col>

--- a/terminal/src/app/pages/tests/Dashboard.test.tsx
+++ b/terminal/src/app/pages/tests/Dashboard.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../../../features/balanceApiSlice", () => ({
       fiat_available: 5,
       fiat_currency: "USDC",
       estimated_total_fiat: 110,
+      total_deposit: 5,
     },
     isLoading: false,
   })),
@@ -98,6 +99,7 @@ describe("Dashboard page", () => {
     expect(
       rtlScreen.getByText("(How efficient are we with risk?)"),
     ).toBeInTheDocument();
+    expect(rtlScreen.getByText("105 USDC")).toBeInTheDocument();
     expect(rtlScreen.getByText("1.27 BTC")).toBeInTheDocument();
   });
 });

--- a/terminal/src/features/features.types.ts
+++ b/terminal/src/features/features.types.ts
@@ -5,8 +5,9 @@ interface AssetCollection {
 export interface BalanceData {
   balances: AssetCollection;
   fiat_available: number;
-  fiat_currency: number;
+  fiat_currency: string;
   estimated_total_fiat: number;
+  total_deposit: number;
 }
 
 // Benchmark of portfolio (in USDC at time of writing) against BTC


### PR DESCRIPTION
### Motivation
- Ensure displayed and persisted portfolio totals reflect net capital by removing KuCoin Futures deposit history from estimated totals.
- Provide a single source of truth for the aggregated deposit amount via the balance API schema to allow front-end adjustments and historical accounting.

### Description
- Added `ConsolidatedAccounts._deposit_amount` and `get_total_deposit` to aggregate deposit sizes from KuCoin futures deposit history and handle different payload shapes and errors (`BinbotErrors`).
- Set `BalanceSchema.total_deposit` in `get_balance` and subtract that value from `estimated_total_fiat` when persisting series in `store_balance` to store net estimated fiat.
- Updated frontend `Dashboard.tsx` to compute and display net total balance and use `total_deposit` when calculating portfolio PnL, and added `netTotalBalance` local variable for the displayed total.
- Updated types in `features.types.ts` to correct `fiat_currency` to a `string` and add `total_deposit: number` to `BalanceData`, and updated `Dashboard.test.tsx` to include `total_deposit` in the mocked response.

### Testing
- Ran the frontend unit test `Dashboard.test.tsx` under Vitest which includes the updated expectation for the displayed net total, and the test passed.
- Type updates were validated by the frontend type-checked build and no type errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3186d4cc483209f8efbc5192eceae)